### PR TITLE
doc(Chart.yaml): Add license header for trg-5-02

### DIFF
--- a/charts/dftbackend/Chart.yaml
+++ b/charts/dftbackend/Chart.yaml
@@ -1,6 +1,7 @@
 #################################################################################
-# Copyright (c) 2021,2022 Catena-X
+
 # Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+# Copyright (c) 2022, 2023 T-Systems International GmbH
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.

--- a/charts/dftbackend/Chart.yaml
+++ b/charts/dftbackend/Chart.yaml
@@ -1,3 +1,23 @@
+#################################################################################
+# Copyright (c) 2021,2022 Catena-X
+# Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+################################################################################
+
 apiVersion: v2
 name: dftbackend
 description: A Helm chart for Kubernetes

--- a/charts/dftbackend/values.yaml
+++ b/charts/dftbackend/values.yaml
@@ -1,6 +1,7 @@
 #################################################################################
-# Copyright (c) 2021,2022 Catena-X
+
 # Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+# Copyright (c) 2022, 2023 T-Systems International GmbH
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.


### PR DESCRIPTION
### Missing License Header
Hello, I would like to suggest adding the license header for the Chart.yaml file to avoid license conflicts and following tractus-x release guidelines: https://eclipse-tractusx.github.io/docs/release/trg-5/trg-5-02

Kind regards

Maximilian Wesener
Traceability-Foss